### PR TITLE
Add e2fsck/resize2fs/tune2fs to recovery/vendor_ramdisk

### DIFF
--- a/target/product/virtual_ab_ota/launch.mk
+++ b/target/product/virtual_ab_ota/launch.mk
@@ -18,4 +18,13 @@ PRODUCT_VIRTUAL_AB_OTA := true
 
 PRODUCT_VENDOR_PROPERTIES += ro.virtual_ab.enabled=true
 
-PRODUCT_PACKAGES += e2fsck_ramdisk
+PRODUCT_PACKAGES += \
+    e2fsck_ramdisk \
+    resize2fs_ramdisk \
+    tune2fs_ramdisk
+
+# For dedicated recovery partitions, we need to include fs tools
+PRODUCT_PACKAGES += \
+    e2fsck.recovery \
+    resize2fs.recovery \
+    tune2fs.recovery

--- a/target/product/virtual_ab_ota/launch_with_vendor_ramdisk.mk
+++ b/target/product/virtual_ab_ota/launch_with_vendor_ramdisk.mk
@@ -25,3 +25,5 @@ PRODUCT_PACKAGES += \
     linker.vendor_ramdisk \
     e2fsck.vendor_ramdisk \
     fsck.f2fs.vendor_ramdisk \
+    resize2fs.vendor_ramdisk \
+    tune2fs.vendor_ramdisk


### PR DESCRIPTION
Fixes: [ERROR]: recovery: [libfs_mgr]Unable to enable ext4 verity on /dev/block/by-name/metadata because /system/bin/tune2fs is missing

in recovery.

Test: e2fsck/resize2fs/tune2fs are present in ramdisks.
Change-Id: I83223f48e4df8b89ff9b27b0912174360c053617