### PR TITLE
Fix error of TARGET_OTA_ASSERT_DEVICE

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -6022,7 +6022,7 @@ ifeq ($(BUILDING_WITH_VSDK),true)
 	$(hide) echo "building_with_vsdk=true" >> $@
 endif
 ifneq ($(TARGET_OTA_ASSERT_DEVICE),)
-        $(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@
+	$(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@
 endif
 
 $(call declare-0p-target,$(INSTALLED_FASTBOOT_INFO_TARGET))


### PR DESCRIPTION
In the Makefile, any line following the target whose first character is a tab is recognized as a command, unless it is a continuation of a previous line using a backslash.

Thus, since the $(hide) is currently preceded by a tab, it is considered to be a continuation of the previous line, as if it were a ifneq ($(TARGET_OTA_ASSERT_DEVICE),) $(hide) echo
"ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@ is written on a single line.

Therefore, the following line cannot be executed correctly $(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@